### PR TITLE
sys/log: Don't increment global log index unless log is persisted

### DIFF
--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -540,7 +540,10 @@ log_append_prepare(struct log *log, uint8_t module, uint8_t level,
 
     OS_ENTER_CRITICAL(sr);
 #if MYNEWT_VAL(LOG_GLOBAL_IDX)
-    idx = g_log_info.li_next_index++;
+    if (log->l_log->log_type == LOG_TYPE_STORAGE) {
+        g_log_info.li_next_index++;
+    }
+    idx = g_log_info.li_next_index;
 #else
     idx = log->l_idx++;
 #endif

--- a/sys/log/full/src/log_shell.c
+++ b/sys/log/full/src/log_shell.c
@@ -69,7 +69,7 @@ shell_log_dump_entry(struct log *log, struct log_offset *log_offset,
         console_printf("[ih=0x%x%x%x%x]", ueh->ue_imghash[0], ueh->ue_imghash[1],
                        ueh->ue_imghash[2], ueh->ue_imghash[3]);
     }
-    console_printf(" [%llu] ", ueh->ue_ts);
+    console_printf(" [%llu]  [ix=%lu]", ueh->ue_ts, ueh->ue_index);
 
     switch (ueh->ue_etype) {
     case LOG_ETYPE_STRING:


### PR DESCRIPTION
The global index is only useful for persisted logs, and if it is incremented for non-persisted logs there will be jumps in the log indexes of the persisted logs. This makes detection of missing logs a challenging task. By incrementing the global index only for persisted logs, it becomes sequentially increasing, which makes detection of missing/dropped logs trivial for upstream consumers of the logs.

This PR also adds the log index ("ix") to the 'log' shell command output.