### PR TITLE
sys/log: Optionally allow "log" command to display log index

### DIFF
--- a/sys/log/full/src/log_shell.c
+++ b/sys/log/full/src/log_shell.c
@@ -69,7 +69,10 @@ shell_log_dump_entry(struct log *log, struct log_offset *log_offset,
         console_printf("[ih=0x%x%x%x%x]", ueh->ue_imghash[0], ueh->ue_imghash[1],
                        ueh->ue_imghash[2], ueh->ue_imghash[3]);
     }
-    console_printf(" [%llu]  [ix=%lu]", ueh->ue_ts, ueh->ue_index);
+    console_printf(" [%llu] ", ueh->ue_ts);
+#if MYNEWT_VAL(LOG_SHELL_SHOW_INDEX)
+    console_printf(" [ix=%lu] ", ueh->ue_index);
+#endif
 
     switch (ueh->ue_etype) {
     case LOG_ETYPE_STRING:

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -69,6 +69,10 @@ syscfg.defs:
         restrictions:
             - SHELL_TASK
 
+    LOG_SHELL_SHOW_INDEX:
+        description: '"log" command shows log index when dumping entries'
+        value: 0
+
     LOG_MGMT:
         description: 'Expose "log" command in mgmt.'
         value: 0


### PR DESCRIPTION
Make displaying the index optional and disabled by default to avoid changing log entry format for existing users of sys/log. 